### PR TITLE
Example not working, wrong spelling.

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -19,7 +19,7 @@
 
     <div class="wrapper">
         Two-way-binding: <input ng-model="data"/>
-        <knob knob-data="data" konb-options="options"></knob>
+        <knob knob-data="data" knob-options="options"></knob>
 
         <hr>
 


### PR DESCRIPTION
Example not working due to wrong spelling of knob-options
